### PR TITLE
Fix new aliased link creation

### DIFF
--- a/admin/components/AliasedLinkModal.tsx
+++ b/admin/components/AliasedLinkModal.tsx
@@ -11,7 +11,7 @@ import {
 import { AliasedLinkType } from "../utils";
 
 interface AliasedLinkModalProps {
-  initialValues?: AliasedLinkType;
+  initialValues?: Partial<AliasedLinkType>;
   form: FormInstance;
   handleSubmit: () => Promise<void>;
   name: string;

--- a/admin/components/NewButton.tsx
+++ b/admin/components/NewButton.tsx
@@ -26,6 +26,7 @@ export default function NewButton() {
       form={form}
       handleSubmit={handleSubmit}
       name="Add aliased link"
+      initialValues={{ public: false }}
     />
   );
 }


### PR DESCRIPTION
The "Add aliased link" button previously led to 500 errors on attempted creation, as the `public` field was not initialized in the form. This PR initializes the `public` field to `false` to remedy this.